### PR TITLE
Fixed missing requires (Ubuntu, Emacs 24.5.1).

### DIFF
--- a/modules/prelude-key-chord.el
+++ b/modules/prelude-key-chord.el
@@ -35,6 +35,7 @@
 
 (require 'key-chord)
 
+
 (key-chord-define-global "jj" 'avy-goto-word-1)
 (key-chord-define-global "jl" 'avy-goto-line)
 (key-chord-define-global "jk" 'avy-goto-char)

--- a/personal/clojure.el
+++ b/personal/clojure.el
@@ -290,4 +290,6 @@ White space here is any of: space, tab, emacs newline (line feed, ASCII 10)."
       (delete-region (car bounds) (cdr bounds))
       (insert (code-box text)))))
 
+(prelude-require-package 'key-chord)
+(require 'key-chord)
 (key-chord-define-global "CB" 'my-comment-box)

--- a/personal/general-conf.el
+++ b/personal/general-conf.el
@@ -142,6 +142,7 @@
 ;; Getting rid of annoying key chords
 ;;
 (prelude-require-package 'key-chord)
+(require 'key-chord)
 ;; disabling lowercase chords
 (key-chord-define-global "jj" nil)
 (key-chord-define-global "jl" nil)

--- a/personal/restclient.el
+++ b/personal/restclient.el
@@ -8,4 +8,5 @@
 ;; restclient company--auto-completion
 ;;
 (prelude-require-package 'company-restclient)
+(require 'company-restclient)
 (add-to-list 'company-backends 'company-restclient)


### PR DESCRIPTION
Startup failed with "symbol's definition is void" error when preludex is installed with Emacs 24.5.1 on Ubuntu. My gut feel is that the order in which the module files are enumerated and loaded by init.el differes betweeen the Mac and Linux. I did not get this issue on my Mac.
